### PR TITLE
add mg_is_websocket_request() to public interface

### DIFF
--- a/mongoose.c
+++ b/mongoose.c
@@ -4200,7 +4200,7 @@ static void handle_websocket_request(struct mg_connection *conn) {
   }
 }
 
-static int is_websocket_request(const struct mg_connection *conn) {
+int mg_is_websocket_request(const struct mg_connection *conn) {
   const char *host, *upgrade, *connection, *version, *key;
 
   host = mg_get_header(conn, "Host");
@@ -4449,7 +4449,7 @@ static void handle_request(struct mg_connection *conn) {
       conn->ctx->callbacks.begin_request(conn)) {
     // Do nothing, callback has served the request
 #if defined(USE_WEBSOCKET)
-  } else if (is_websocket_request(conn)) {
+  } else if (mg_is_websocket_request(conn)) {
     handle_websocket_request(conn);
 #endif
   } else if (!strcmp(ri->request_method, "OPTIONS")) {

--- a/mongoose.h
+++ b/mongoose.h
@@ -231,6 +231,13 @@ enum {
   WEBSOCKET_OPCODE_PONG = 0xa
 };
 
+// Check whether request is a websocket request
+//
+// Return:
+//  1   request is a websocket request
+//  0   request is not a websocket request
+int mg_is_websocket_request(const struct mg_connection *conn);
+
 
 // Macros for enabling compiler-specific checks for printf-like arguments.
 #undef PRINTF_FORMAT_STRING


### PR DESCRIPTION
It is useful to be able to determine whether a particular request is a websocket request so that in the begin_request callback, for example, you can terminate non-websocket requests made to paths that expect websocket connections.
